### PR TITLE
Add Ed25519 key support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>com.coinbase.advanced</groupId>
   <name>Coinbase Advanced Trade Java SDK</name>
   <description>Sample Java SDK for the Coinbase Advanced REST APIs</description>
-  <version>0.2.1</version>
+  <version>0.2.2</version>
   <url>https://github.com/coinbase-samples/advanced-sdk-java</url>
   <licenses>
     <license>

--- a/src/main/java/com/coinbase/advanced/credentials/CoinbaseAdvancedCredentials.java
+++ b/src/main/java/com/coinbase/advanced/credentials/CoinbaseAdvancedCredentials.java
@@ -23,21 +23,35 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.*;
 import com.nimbusds.jose.crypto.*;
+import com.nimbusds.jose.jca.JCAContext;
+import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.*;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
+import org.bouncycastle.crypto.util.PrivateKeyInfoFactory;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 
 import java.io.StringReader;
 import java.net.URI;
+import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
+import java.security.SecureRandom;
 import java.security.Security;
+import java.security.Signature;
 import java.security.interfaces.ECPrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Instant;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class CoinbaseAdvancedCredentials implements CoinbaseCredentials {
     @JsonProperty(required = true)
@@ -87,51 +101,172 @@ public class CoinbaseAdvancedCredentials implements CoinbaseCredentials {
     public String generateJwt(String requestMethod, String host, String path) throws Exception {
         Security.addProvider(new BouncyCastleProvider());
 
-        Map<String, Object> header = new HashMap<>();
-        header.put("alg", "ES256");
-        header.put("typ", "JWT");
-        header.put("kid", apiKeyName);
-        header.put("nonce", String.valueOf(Instant.now().getEpochSecond()));
+        PrivateKey key = loadPrivateKey(privateKey);
+        JWSAlgorithm algorithm = algorithmFor(key);
+        if (JWSAlgorithm.ES256.equals(algorithm)) {
+            warnEcdsaDeprecation();
+        }
 
         String uri = requestMethod + " " + host + path;
+        long now = Instant.now().getEpochSecond();
 
-        Map<String, Object> data = new HashMap<>();
-        data.put("iss", "cdp");
-        data.put("nbf", Instant.now().getEpochSecond());
-        data.put("exp", Instant.now().getEpochSecond() + 120);
-        data.put("sub", apiKeyName);
-        data.put("uri", uri);
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+                .subject(apiKeyName)
+                .issuer("cdp")
+                .notBeforeTime(Date.from(Instant.ofEpochSecond(now)))
+                .expirationTime(Date.from(Instant.ofEpochSecond(now + 120)))
+                .claim("uri", uri)
+                .build();
 
-        try (PEMParser pemParser = new PEMParser(new StringReader(privateKey))) {
-            JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
-            Object object = pemParser.readObject();
-            PrivateKey privateKey;
+        JWSHeader jwsHeader = new JWSHeader.Builder(algorithm)
+                .type(JOSEObjectType.JWT)
+                .keyID(apiKeyName)
+                .customParam("nonce", generateNonce())
+                .build();
 
-            if (object instanceof PrivateKey) {
-                privateKey = (PrivateKey) object;
-            } else if (object instanceof org.bouncycastle.openssl.PEMKeyPair) {
-                privateKey = converter.getPrivateKey(((org.bouncycastle.openssl.PEMKeyPair) object).getPrivateKeyInfo());
-            } else {
-                throw new Exception("Unexpected private key format");
+        SignedJWT signedJWT = new SignedJWT(jwsHeader, claimsSet);
+        signedJWT.sign(signerFor(algorithm, key));
+
+        return signedJWT.serialize();
+    }
+
+    private static final AtomicBoolean ecdsaDeprecationWarned = new AtomicBoolean(false);
+
+    /**
+     * Loads a CDP API key secret into a {@link PrivateKey}. Two key types are
+     * supported:
+     * <ul>
+     *   <li>ECDSA (P-256), signed with ES256. Supplied as a PEM-encoded key.</li>
+     *   <li>Ed25519, signed with EdDSA. Supplied either as a PKCS#8 PEM key or as
+     *       a base64-encoded raw key (32-byte seed or 64-byte seed+public key),
+     *       which is how the CDP portal hands out Ed25519 secrets.</li>
+     * </ul>
+     */
+    private static PrivateKey loadPrivateKey(String secret) throws Exception {
+        String trimmed = secret.trim();
+
+        if (trimmed.startsWith("-----BEGIN")) {
+            PrivateKey key;
+            try (PEMParser pemParser = new PEMParser(new StringReader(secret))) {
+                JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+                Object object = pemParser.readObject();
+                if (object instanceof PEMKeyPair) {
+                    key = converter.getPrivateKey(((PEMKeyPair) object).getPrivateKeyInfo());
+                } else if (object instanceof PrivateKeyInfo) {
+                    key = converter.getPrivateKey((PrivateKeyInfo) object);
+                } else if (object instanceof PrivateKey) {
+                    key = (PrivateKey) object;
+                } else {
+                    throw new CoinbaseClientException("Unexpected private key format");
+                }
             }
-
-            KeyFactory keyFactory = KeyFactory.getInstance("EC");
-            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateKey.getEncoded());
-            ECPrivateKey ecPrivateKey = (ECPrivateKey) keyFactory.generatePrivate(keySpec);
-
-            JWTClaimsSet.Builder claimsSetBuilder = new JWTClaimsSet.Builder();
-            for (Map.Entry<String, Object> entry : data.entrySet()) {
-                claimsSetBuilder.claim(entry.getKey(), entry.getValue());
+            // Normalize EC keys through the default provider so nimbus signs them
+            // exactly as before; Ed25519 keys are returned as-is for the BC signer.
+            if (isEc(key.getAlgorithm())) {
+                KeyFactory keyFactory = KeyFactory.getInstance("EC");
+                return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(key.getEncoded()));
             }
-            JWTClaimsSet claimsSet = claimsSetBuilder.build();
+            return key;
+        }
 
-            JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES256).customParams(header).build();
-            SignedJWT signedJWT = new SignedJWT(jwsHeader, claimsSet);
+        byte[] raw;
+        try {
+            raw = Base64.getDecoder().decode(trimmed.replaceAll("\\s", ""));
+        } catch (IllegalArgumentException e) {
+            throw new CoinbaseClientException("private key is neither PEM nor valid base64", e);
+        }
+        if (raw.length != 32 && raw.length != 64) {
+            throw new CoinbaseClientException(
+                    "Ed25519 raw key must decode to 32 or 64 bytes, got " + raw.length);
+        }
+        // The constructor reads the 32-byte seed from offset 0, ignoring the
+        // trailing public key bytes when a 64-byte key is supplied.
+        Ed25519PrivateKeyParameters params = new Ed25519PrivateKeyParameters(raw, 0);
+        PrivateKeyInfo keyInfo = PrivateKeyInfoFactory.createPrivateKeyInfo(params);
+        KeyFactory keyFactory = KeyFactory.getInstance("Ed25519", "BC");
+        return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(keyInfo.getEncoded()));
+    }
 
-            JWSSigner signer = new ECDSASigner(ecPrivateKey);
-            signedJWT.sign(signer);
+    private static JWSAlgorithm algorithmFor(PrivateKey key) {
+        String alg = key.getAlgorithm();
+        if (isEd25519(alg)) {
+            return JWSAlgorithm.EdDSA;
+        }
+        if (isEc(alg)) {
+            return JWSAlgorithm.ES256;
+        }
+        throw new IllegalArgumentException(
+                "Unsupported private key type: " + alg + ". Expected ECDSA (P-256) or Ed25519.");
+    }
 
-            return signedJWT.serialize();
+    private static void warnEcdsaDeprecation() {
+        if (ecdsaDeprecationWarned.compareAndSet(false, true)) {
+            System.err.println("warning: Ed25519 is the recommended CDP API key type. "
+                    + "Consider switching to an Ed25519 key at https://portal.cdp.coinbase.com/");
+        }
+    }
+
+    private static JWSSigner signerFor(JWSAlgorithm algorithm, PrivateKey key) throws JOSEException {
+        if (JWSAlgorithm.EdDSA.equals(algorithm)) {
+            return new Ed25519JwsSigner(key);
+        }
+        return new ECDSASigner((ECPrivateKey) key);
+    }
+
+    private static boolean isEc(String alg) {
+        return "EC".equalsIgnoreCase(alg) || "ECDSA".equalsIgnoreCase(alg);
+    }
+
+    private static boolean isEd25519(String alg) {
+        return "Ed25519".equalsIgnoreCase(alg) || "EdDSA".equalsIgnoreCase(alg);
+    }
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private static String generateNonce() {
+        byte[] bytes = new byte[16];
+        SECURE_RANDOM.nextBytes(bytes);
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+            sb.append(Character.forDigit(b & 0xF, 16));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * A nimbus {@link JWSSigner} for EdDSA backed by BouncyCastle, so Ed25519
+     * signing works without pulling in the Tink dependency nimbus otherwise
+     * requires for OKP keys.
+     */
+    private static final class Ed25519JwsSigner implements JWSSigner {
+        private final PrivateKey privateKey;
+        private final JCAContext jcaContext = new JCAContext();
+
+        Ed25519JwsSigner(PrivateKey privateKey) {
+            this.privateKey = privateKey;
+        }
+
+        @Override
+        public Base64URL sign(JWSHeader header, byte[] signingInput) throws JOSEException {
+            try {
+                Signature signature = Signature.getInstance("Ed25519", BouncyCastleProvider.PROVIDER_NAME);
+                signature.initSign(privateKey);
+                signature.update(signingInput);
+                return Base64URL.encode(signature.sign());
+            } catch (GeneralSecurityException e) {
+                throw new JOSEException("Ed25519 signing failed: " + e.getMessage(), e);
+            }
+        }
+
+        @Override
+        public Set<JWSAlgorithm> supportedJWSAlgorithms() {
+            return Collections.singleton(JWSAlgorithm.EdDSA);
+        }
+
+        @Override
+        public JCAContext getJCAContext() {
+            return jcaContext;
         }
     }
 }

--- a/src/main/java/com/coinbase/advanced/credentials/CoinbaseAdvancedCredentials.java
+++ b/src/main/java/com/coinbase/advanced/credentials/CoinbaseAdvancedCredentials.java
@@ -51,7 +51,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class CoinbaseAdvancedCredentials implements CoinbaseCredentials {
     @JsonProperty(required = true)
@@ -103,9 +102,6 @@ public class CoinbaseAdvancedCredentials implements CoinbaseCredentials {
 
         PrivateKey key = loadPrivateKey(privateKey);
         JWSAlgorithm algorithm = algorithmFor(key);
-        if (JWSAlgorithm.ES256.equals(algorithm)) {
-            warnEcdsaDeprecation();
-        }
 
         String uri = requestMethod + " " + host + path;
         long now = Instant.now().getEpochSecond();
@@ -129,8 +125,6 @@ public class CoinbaseAdvancedCredentials implements CoinbaseCredentials {
 
         return signedJWT.serialize();
     }
-
-    private static final AtomicBoolean ecdsaDeprecationWarned = new AtomicBoolean(false);
 
     /**
      * Loads a CDP API key secret into a {@link PrivateKey}. Two key types are
@@ -197,13 +191,6 @@ public class CoinbaseAdvancedCredentials implements CoinbaseCredentials {
         }
         throw new IllegalArgumentException(
                 "Unsupported private key type: " + alg + ". Expected ECDSA (P-256) or Ed25519.");
-    }
-
-    private static void warnEcdsaDeprecation() {
-        if (ecdsaDeprecationWarned.compareAndSet(false, true)) {
-            System.err.println("warning: Ed25519 is the recommended CDP API key type. "
-                    + "Consider switching to an Ed25519 key at https://portal.cdp.coinbase.com/");
-        }
     }
 
     private static JWSSigner signerFor(JWSAlgorithm algorithm, PrivateKey key) throws JOSEException {

--- a/src/main/java/com/coinbase/advanced/utils/Constants.java
+++ b/src/main/java/com/coinbase/advanced/utils/Constants.java
@@ -18,7 +18,7 @@ package com.coinbase.advanced.utils;
 
 public class Constants {
     public static final String BASE_URL = "https://api.coinbase.com/api/v3";
-    public static final String SDK_VERSION = "0.1.0";
+    public static final String SDK_VERSION = "0.2.2";
     public static final String USER_AGENT_HEADER = "User-Agent";
     public static final String AUTH_HEADER = "Authorization";
 }


### PR DESCRIPTION
## What

Adds Ed25519 (EdDSA) signing support to the JWT auth path, alongside the existing ECDSA (ES256) keys.

- `generateJwt` now detects the key type and signs accordingly:
  - ECDSA keys (PEM) sign with ES256, same as before.
  - Ed25519 keys sign with EdDSA, accepted either as a PKCS#8 PEM or as the base64 raw key the CDP portal hands out (32-byte seed or 64-byte seed+pubkey). Whitespace in the base64 is tolerated.
- Ed25519 signing uses a small BouncyCastle-backed `JWSSigner`, so no new dependency is needed (nimbus would otherwise require Tink for OKP keys). EC keys are normalized through the default provider so the existing ECDSA path is unchanged.
- Nonce is now a random value instead of the epoch second (the old one repeated for tokens minted in the same second).
- Bumps the version to 0.2.2 and updates `SDK_VERSION` so the User-Agent reports the right version.

## Testing

Verified against the live API with both ECDSA and Ed25519 keys: JWT structural checks (alg, kid, sub, nbf/exp, distinct nonces, signature verifies), a malformed-secret negative case, plus real REST calls all pass.